### PR TITLE
Change Provider.CDM to Provider.CWM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export const initStore: Function = (store, ...middlewares) => {
   class Provider extends Component<*> {
     state = store.initialState
 
-    componentDidMount() {
+    componentWillMount() {
       self = this
       initializedMiddlewares = middlewares.map(m => m(store, self))
     }


### PR DESCRIPTION
When you have a structure like the following:

```
// Router.jsx
import React, { Component } from 'react';
import { Provider } from 'store';
import { User } from 'components/User';

export class Router extends Component {
    render() {
        return (
            <Provider>
                <User />
            </Provider>
        );
    }
}


// User.jsx
import React, { Component } from 'react';
import { actions, connect } from 'store';

class UserClass extends Component {
    componentDidMount() {
        actions.getUser();
    }
    
    render() {
        const { state } = this.props;
        return (
            <div>Hello { state.user.name } what up dude</div>
        );
    }
}

export const User = connect(['user'])(UserClass);
```

You get an error: `Provider is not rendered yet` when `actions.getUser()` inside of `User.componentDidMount` is called.

I believe this happens because `User's componentDidMount` is called before its parent's (`<Provider />`) `componentDidMount` is called.

Changing to `componentWillMount` "fixes" the issue because that lifecycle method is called before any `componentDidMount` call.